### PR TITLE
Add user profile update endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Api;
 use Illuminate\Http\Request;
 use App\Helpers\ApiResponse;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Hash;
 class ProfileController extends Controller
 {
     public function show(Request $request)
@@ -12,6 +14,44 @@ class ProfileController extends Controller
         return ApiResponse::success(
             ['user' => $request->user()],
             __('messages.profile_retrieved')
+        );
+    }
+
+    public function update(Request $request)
+    {
+        $user = $request->user();
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'sometimes|required|string|max:255',
+            'email' => 'sometimes|required|email|unique:users,email,' . $user->id,
+            'password' => 'sometimes|required|min:6|confirmed',
+        ]);
+
+        if ($validator->fails()) {
+            return ApiResponse::error(
+                __('messages.validation_error'),
+                $validator->errors(),
+                422
+            );
+        }
+
+        if ($request->filled('name')) {
+            $user->name = $request->name;
+        }
+
+        if ($request->filled('email')) {
+            $user->email = $request->email;
+        }
+
+        if ($request->filled('password')) {
+            $user->password = Hash::make($request->password);
+        }
+
+        $user->save();
+
+        return ApiResponse::success(
+            ['user' => $user],
+            __('messages.profile_updated')
         );
     }
 }

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -14,4 +14,5 @@ return [
     'password_reset_failed' => 'Failed to reset password. Token may be invalid or expired.',
     'invalid_credentials' => 'Invalid credentials provided.',
     'profile_retrieved' => 'User profile retrieved successfully.',
+    'profile_updated' => 'User profile updated successfully.',
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 
 // Authenticated user info (requires Sanctum token)
 Route::middleware('auth:sanctum')->get('/user', [ProfileController::class, 'show']);
+Route::middleware('auth:sanctum')->put('/user', [ProfileController::class, 'update']);
 
 // Guest routes
 Route::middleware('guest')->group(function () {


### PR DESCRIPTION
## Summary
- implement user profile update method
- wire up route for updating the authenticated user
- add translation message

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a97548178832283f05f93ffd8ce72