### PR TITLE
Add details endpoints for categories, merchants and products

### DIFF
--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -35,6 +35,12 @@ class CategoryController extends Controller
         return ApiResponse::success(CategoryResource::collection($latestCategories), __('messages.categories_retrieved'));
     }
 
+    // Method to get the details of a single category
+    public function details(Category $category)
+    {
+        return ApiResponse::success(new CategoryResource($category), 'Category details retrieved successfully.');
+    }
+
 
 
 

--- a/app/Http/Controllers/Api/MerchantController.php
+++ b/app/Http/Controllers/Api/MerchantController.php
@@ -48,4 +48,10 @@ class MerchantController extends Controller
         return ApiResponse::success(MerchantResource::collection($latest), 'Latest merchants retrieved successfully.');
     }
 
+    // Method to get the details of a single merchant
+    public function details(Merchant $merchant)
+    {
+        return ApiResponse::success(new MerchantResource($merchant), 'Merchant details retrieved successfully.');
+    }
+
 }

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -47,4 +47,10 @@ class ProductController extends Controller
 
         return ApiResponse::success(ProductResource::collection($latest), 'Latest products retrieved successfully.');
     }
+
+    // Method to get the details of a single product
+    public function details(Product $product)
+    {
+        return ApiResponse::success(new ProductResource($product), 'Product details retrieved successfully.');
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,15 +50,18 @@ Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
 Route::apiResource('categories', CategoryController::class)->only(['index', 'show']);
 Route::get('/categories-latest', [CategoryController::class, 'latest']);
 Route::get('/categories-featured', [CategoryController::class, 'latest']); //TODO - implement featured flag
+Route::get('/categories/{category}/details', [CategoryController::class, 'details']);
 
 
 Route::apiResource('merchants', MerchantController::class)->only(['index', 'show']);
 Route::get('/merchants-latest', [MerchantController::class, 'latest']);
 Route::get('/merchants-featured', [MerchantController::class, 'latest']); //TODO - implement featured flag
+Route::get('/merchants/{merchant}/details', [MerchantController::class, 'details']);
 
 Route::apiResource('products', ProductController::class)->only(['index', 'show']);
 Route::get('/products-latest', [ProductController::class, 'latest']);
 Route::get('/products-featured', [ProductController::class, 'latest']); //TODO - implement featured flag
+Route::get('/products/{product}/details', [ProductController::class, 'details']);
 
 
 //TODO


### PR DESCRIPTION
## Summary
- implement `details` methods in `CategoryController`, `MerchantController` and `ProductController`
- add routes to expose the new details endpoints

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baa7bd7b88322a8097272b5e8b7e0