### PR TITLE
Add related resources to details endpoints

### DIFF
--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -38,7 +38,16 @@ class CategoryController extends Controller
     // Method to get the details of a single category
     public function details(Category $category)
     {
-        return ApiResponse::success(new CategoryResource($category), 'Category details retrieved successfully.');
+        // Fetch 4 random categories excluding the one being shown
+        $related = Category::where('id', '!=', $category->id)
+            ->inRandomOrder()
+            ->take(4)
+            ->get();
+
+        return ApiResponse::success([
+            'item' => new CategoryResource($category),
+            'related' => CategoryResource::collection($related),
+        ], 'Category details retrieved successfully.');
     }
 
 

--- a/app/Http/Controllers/Api/MerchantController.php
+++ b/app/Http/Controllers/Api/MerchantController.php
@@ -51,7 +51,16 @@ class MerchantController extends Controller
     // Method to get the details of a single merchant
     public function details(Merchant $merchant)
     {
-        return ApiResponse::success(new MerchantResource($merchant), 'Merchant details retrieved successfully.');
+        // Fetch 4 random merchants excluding the current one
+        $related = Merchant::where('id', '!=', $merchant->id)
+            ->inRandomOrder()
+            ->take(4)
+            ->get();
+
+        return ApiResponse::success([
+            'item' => new MerchantResource($merchant),
+            'related' => MerchantResource::collection($related),
+        ], 'Merchant details retrieved successfully.');
     }
 
 }

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -51,6 +51,15 @@ class ProductController extends Controller
     // Method to get the details of a single product
     public function details(Product $product)
     {
-        return ApiResponse::success(new ProductResource($product), 'Product details retrieved successfully.');
+        // Fetch 4 random products excluding the current one
+        $related = Product::where('id', '!=', $product->id)
+            ->inRandomOrder()
+            ->take(4)
+            ->get();
+
+        return ApiResponse::success([
+            'item' => new ProductResource($product),
+            'related' => ProductResource::collection($related),
+        ], 'Product details retrieved successfully.');
     }
 }


### PR DESCRIPTION
## Summary
- extend category, merchant, and product detail endpoints
- include 4 random related items in each response

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb25ceb008322bca2bd846ab4b127