### PR TITLE
Add user stats endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -17,6 +17,24 @@ class ProfileController extends Controller
         );
     }
 
+    public function stats(Request $request)
+    {
+        $data = [
+            'balance' => 40.0,
+            'balance_goal' => 50.0,
+            'pending_cashback' => 14.35,
+            'products_earned' => 6,
+            'stores_earned' => 2,
+            'orders_count' => 12,
+            'currency' => 'EUR',
+        ];
+
+        return ApiResponse::success(
+            $data,
+            __('messages.stats_retrieved')
+        );
+    }
+
     public function update(Request $request)
     {
         $user = $request->user();

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -15,4 +15,5 @@ return [
     'invalid_credentials' => 'Invalid credentials provided.',
     'profile_retrieved' => 'User profile retrieved successfully.',
     'profile_updated' => 'User profile updated successfully.',
+    'stats_retrieved' => 'User stats retrieved successfully.',
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 // Authenticated user info (requires Sanctum token)
 Route::middleware('auth:sanctum')->get('/user', [ProfileController::class, 'show']);
 Route::middleware('auth:sanctum')->put('/user', [ProfileController::class, 'update']);
+Route::middleware('auth:sanctum')->get('/user/stats', [ProfileController::class, 'stats']);
 
 // Guest routes
 Route::middleware('guest')->group(function () {


### PR DESCRIPTION
## Summary
- add `/api/user/stats` route
- implement `stats` method in `ProfileController`
- add translation message for stats retrieval

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865261fe30c8322ab6bd39c1b220e80