### PR TITLE
Add user orders history endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -35,6 +35,107 @@ class ProfileController extends Controller
         );
     }
 
+    public function orders(Request $request)
+    {
+        $orders = [
+            [
+                'id' => 1,
+                'store_name' => 'NovaShop',
+                'store_url' => 'https://novashop.com',
+                'status' => 'pending',
+                'ordered_at' => '15.03.2026 09:45 AM',
+                'order_total' => 200.0,
+                'cashback_amount' => 5.0,
+                'currency' => 'EUR',
+            ],
+            [
+                'id' => 2,
+                'store_name' => 'TechZone',
+                'store_url' => 'https://techzone.com',
+                'status' => 'complete',
+                'ordered_at' => '07.03.2026 10:00 AM',
+                'order_total' => 150.0,
+                'cashback_amount' => 3.0,
+                'currency' => 'EUR',
+            ],
+            [
+                'id' => 3,
+                'store_name' => 'GadgetWorld',
+                'store_url' => 'https://gadgetworld.com',
+                'status' => 'pending',
+                'ordered_at' => '20.03.2026 08:15 PM',
+                'order_total' => 475.25,
+                'cashback_amount' => 9.5,
+                'currency' => 'USD',
+            ],
+            [
+                'id' => 4,
+                'store_name' => 'EcoMart',
+                'store_url' => 'https://ecomart.com',
+                'status' => 'complete',
+                'ordered_at' => '01.04.2026 01:30 PM',
+                'order_total' => 90.0,
+                'cashback_amount' => 2.5,
+                'currency' => 'EUR',
+            ],
+            [
+                'id' => 5,
+                'store_name' => 'DailyFresh',
+                'store_url' => 'https://dailyfresh.com',
+                'status' => 'complete',
+                'ordered_at' => '12.04.2026 11:20 AM',
+                'order_total' => 35.0,
+                'cashback_amount' => 1.0,
+                'currency' => 'EUR',
+            ],
+            [
+                'id' => 6,
+                'store_name' => 'StyleHub',
+                'store_url' => 'https://stylehub.com',
+                'status' => 'pending',
+                'ordered_at' => '21.04.2026 05:00 PM',
+                'order_total' => 220.0,
+                'cashback_amount' => 6.0,
+                'currency' => 'EUR',
+            ],
+            [
+                'id' => 7,
+                'store_name' => 'TravelEasy',
+                'store_url' => 'https://traveleasy.com',
+                'status' => 'complete',
+                'ordered_at' => '28.04.2026 09:45 AM',
+                'order_total' => 800.0,
+                'cashback_amount' => 20.0,
+                'currency' => 'USD',
+            ],
+            [
+                'id' => 8,
+                'store_name' => 'BookSpace',
+                'store_url' => 'https://bookspace.com',
+                'status' => 'pending',
+                'ordered_at' => '02.05.2026 03:15 PM',
+                'order_total' => 60.0,
+                'cashback_amount' => 1.2,
+                'currency' => 'EUR',
+            ],
+            [
+                'id' => 9,
+                'store_name' => 'PetParadise',
+                'store_url' => 'https://petparadise.com',
+                'status' => 'complete',
+                'ordered_at' => '10.05.2026 12:30 PM',
+                'order_total' => 110.0,
+                'cashback_amount' => 2.75,
+                'currency' => 'USD',
+            ],
+        ];
+
+        return ApiResponse::success(
+            $orders,
+            __('messages.orders_retrieved')
+        );
+    }
+
     public function update(Request $request)
     {
         $user = $request->user();

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -16,4 +16,5 @@ return [
     'profile_retrieved' => 'User profile retrieved successfully.',
     'profile_updated' => 'User profile updated successfully.',
     'stats_retrieved' => 'User stats retrieved successfully.',
+    'orders_retrieved' => 'User orders retrieved successfully.',
 ];

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -3,4 +3,5 @@ return [
     'categories_retrieved' => 'Categoriile au fost recuperate cu succes.',
     'validation_error' => 'A aparut o eroare de validare.',
     'email_verified' => 'Emailul a fost verificat cu succes.',
+    'orders_retrieved' => 'Istoricul comenzilor a fost preluat cu succes.',
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 Route::middleware('auth:sanctum')->get('/user', [ProfileController::class, 'show']);
 Route::middleware('auth:sanctum')->put('/user', [ProfileController::class, 'update']);
 Route::middleware('auth:sanctum')->get('/user/stats', [ProfileController::class, 'stats']);
+Route::middleware('auth:sanctum')->get('/user/orders', [ProfileController::class, 'orders']);
 
 // Guest routes
 Route::middleware('guest')->group(function () {


### PR DESCRIPTION
## Summary
- implement `/api/user/orders` API route
- stub dummy data for order history in `ProfileController`
- add translation string for orders retrieval message

## Testing
- `php -v` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652a9df32c832298d2e0f34fe760d0