### PR TITLE
Add dummy product search route

### DIFF
--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -62,4 +62,24 @@ class ProductController extends Controller
             'related' => ProductResource::collection($related),
         ], 'Product details retrieved successfully.');
     }
+
+    // Dummy search endpoint
+    public function search(Request $request)
+    {
+        $query = $request->query('query', 'Product');
+        $limit = (int) $request->query('limit', 5);
+
+        $results = [];
+        for ($i = 1; $i <= $limit; $i++) {
+            $results[] = [
+                'title' => $query . " " . $i,
+                'url' => 'https://example.com/products/' . $i,
+                'merchant' => 'Example Merchant',
+                'image' => 'https://example.com/images/product-' . $i . '.jpg',
+                'price' => '$' . number_format(99.99 + $i, 2),
+            ];
+        }
+
+        return ApiResponse::success($results, 'Search results retrieved successfully.');
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,7 @@ Route::apiResource('products', ProductController::class)->only(['index', 'show']
 Route::get('/products-latest', [ProductController::class, 'latest']);
 Route::get('/products-featured', [ProductController::class, 'latest']); //TODO - implement featured flag
 Route::get('/products/{product}/details', [ProductController::class, 'details']);
+Route::get('/products/search', [ProductController::class, 'search']);
 
 
 //TODO


### PR DESCRIPTION
## Summary
- add dummy `search` method to ProductController
- wire up new `/api/products/search` route

## Testing
- `php -l app/Http/Controllers/Api/ProductController.php`
- `php -l routes/api.php`
- `composer install` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6874c438d23c83228143cc211669dc2f