### PR TITLE
Add product price alert endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -87,4 +87,13 @@ class ProductController extends Controller
 
         return ApiResponse::success($results, 'Search results retrieved successfully.');
     }
+
+    // Dummy price alert endpoint
+    public function priceAlert(Product $product)
+    {
+        return ApiResponse::success(
+            [],
+            "You'll be notified on your email when the price for this product changes."
+        );
+    }
 }

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -17,4 +17,5 @@ return [
     'profile_updated' => 'User profile updated successfully.',
     'stats_retrieved' => 'User stats retrieved successfully.',
     'orders_retrieved' => 'User orders retrieved successfully.',
+    'price_alert_subscribed' => "You'll be notified on your email when the price for this product changes.",
 ];

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -4,4 +4,5 @@ return [
     'validation_error' => 'A aparut o eroare de validare.',
     'email_verified' => 'Emailul a fost verificat cu succes.',
     'orders_retrieved' => 'Istoricul comenzilor a fost preluat cu succes.',
+    'price_alert_subscribed' => 'Veți fi notificat pe email când prețul acestui produs se modifică.',
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,7 @@ Route::get('/products-latest', [ProductController::class, 'latest']);
 Route::get('/products-featured', [ProductController::class, 'latest']); //TODO - implement featured flag
 Route::get('/products/{product}/details', [ProductController::class, 'details']);
 Route::get('/products-search', [ProductController::class, 'search']);
+Route::middleware('auth:sanctum')->post('/products/{product}/price-alert', [ProductController::class, 'priceAlert']);
 
 
 //TODO


### PR DESCRIPTION
## Summary
- add dummy price alert endpoint in `ProductController`
- expose route for authenticated users
- add translation strings

## Testing
- `php -l app/Http/Controllers/Api/ProductController.php`
- `php -l routes/api.php`
- `php -l resources/lang/en/messages.php`
- `php -l resources/lang/ro/messages.php`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6877741896648322abc77f99bf33d4c6